### PR TITLE
fix: change the type of httpCli to HTTPClient

### DIFF
--- a/store.go
+++ b/store.go
@@ -47,7 +47,7 @@ type StoreConfig struct {
 
 type StoreClient struct {
 	Token   *Token
-	httpCli *http.Client
+	httpCli HTTPClient
 	cert    *Cert
 	hostUrl string
 }
@@ -73,7 +73,7 @@ func NewStoreClient(config *StoreConfig) *StoreClient {
 }
 
 // NewStoreClientWithHTTPClient creates a appstore server api client with a custom http client.
-func NewStoreClientWithHTTPClient(config *StoreConfig, httpClient *http.Client) *StoreClient {
+func NewStoreClientWithHTTPClient(config *StoreConfig, httpClient HTTPClient) *StoreClient {
 	token := &Token{}
 	token.WithConfig(config)
 	hostUrl := HostProduction


### PR DESCRIPTION
PR about #11 

I think type of httpClient in StoreClient is `*http.Client`, so user can't use those functions like SetResponseErrorHandler, SetRetry out of library code to wrap client.

I expect that after this change, user can write below code.
```
        httpClient := &http.Client{}
	client := SetRetry(httpClient, &JitterBackoff{}, ShouldRetryDefault)
	storeClient := NewStoreClientWithHTTPClient(&StoreConfig{...}, client)
```

Feel free to give your opinion that improves this PR or change the way of implementation.
Thank you.