### PR TITLE
fix: Add omitempty to OnlyFailures and TransactionId filed in NotificationHistoryRequest struct

### DIFF
--- a/model.go
+++ b/model.go
@@ -212,8 +212,8 @@ type NotificationHistoryRequest struct {
 	OriginalTransactionId string             `json:"originalTransactionId,omitempty"`
 	NotificationType      NotificationTypeV2 `json:"notificationType,omitempty"`
 	NotificationSubtype   SubtypeV2          `json:"notificationSubtype,omitempty"`
-	OnlyFailures          bool               `json:"onlyFailures"`
-	TransactionId         string             `json:"transactionId"`
+	OnlyFailures          bool               `json:"onlyFailures,omitempty"`
+	TransactionId         string             `json:"transactionId,omitempty"`
 }
 
 type NotificationTypeV2 string


### PR DESCRIPTION
In NotificationHistoryRequest, according Apple's document, only startTime and endTime are required, all other field is optional.

> Specify the constraints for the App Store Server Notification history entries you’re requesting from [Get Notification History](https://developer.apple.com/documentation/appstoreserverapi/get_notification_history). The request requires the startDate and endDate fields; all other fields are optional. Include only the fields in your request that you need to constrain the response.

https://developer.apple.com/documentation/appstoreserverapi/notificationhistoryrequest