### PR TITLE
feat: Support setting the audience (aud)

### DIFF
--- a/store.go
+++ b/store.go
@@ -40,6 +40,7 @@ type StoreConfig struct {
 	KeyID              string         // Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
 	BundleID           string         // Your app’s bundle ID
 	Issuer             string         // Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
+	Audience           string         // Your audience (aud) for generating the token (some Apple APIs require a specific aud, such as Sign In with Apple ID).
 	Sandbox            bool           // default is Production
 	TokenIssuedAtFunc  func() int64   // The token’s creation time func. Default is current timestamp.
 	TokenExpiredAtFunc func() int64   // The token’s expiration time func. Default is one hour later.

--- a/token.go
+++ b/token.go
@@ -18,6 +18,7 @@ import (
 var (
 	ErrAuthKeyInvalidPem  = errors.New("token: AuthKey must be a valid .p8 PEM file")
 	ErrAuthKeyInvalidType = errors.New("token: AuthKey must be of type ecdsa.PrivateKey")
+	DefaultAudience       = "appstoreconnect-v1"
 )
 
 // Token represents an Apple Provider Authentication Token (JSON Web Token).
@@ -92,7 +93,7 @@ func (t *Token) Generate() error {
 	}
 	audience := t.Audience
 	if audience == "" {
-		audience = "appstoreconnect-v1"
+		audience = DefaultAudience
 	}
 	jwtToken := &jwt.Token{
 		Header: map[string]interface{}{


### PR DESCRIPTION
Support allowing users to set the signing audience, as some Apple APIs require a specific audience.